### PR TITLE
Build Linux releases for Python 3.12

### DIFF
--- a/.github/workflows/buildReleaseAndPublish.yml
+++ b/.github/workflows/buildReleaseAndPublish.yml
@@ -26,7 +26,7 @@ jobs:
     strategy:
       matrix:
         package: [torch-mlir]
-        py_version: [cp310-cp310, cp311-cp311]
+        py_version: [cp310-cp310, cp311-cp311, cp312-cp312]
 
     steps:
       - name: Checkout torch-mlir


### PR DESCRIPTION
The default Python version on Ubuntu 24.04 LTS and other distribtions like Gentoo is Python 3.12, therefore building wheels for Python 3.12 seems reasonable.